### PR TITLE
This adds api key from environment variable

### DIFF
--- a/Drinks/lambda_function.py
+++ b/Drinks/lambda_function.py
@@ -10,6 +10,7 @@ from __future__ import print_function
 
 from botocore.vendored import requests
 from pprint import pprint
+import os
 
 # Helper function: Given a drink, get the ingredients in an array
 def getIngredients(requestedDrink):
@@ -70,7 +71,10 @@ def getDrinkInformation(drink):
 
     DRINK = None #Global variable to hold the drink that is being instructed on
     drink.replace(" ", "_")
-    response = requests.get("http://www.thecocktaildb.com/api/json/v1/1/search.php?s=%s" % (drink))
+    api_key = "1"
+    if ("COCKTAIL_DB_API_KEY" in os.environ):
+        api_key = os.environ["COCKTAIL_DB_API_KEY"]
+    response = requests.get("http://www.thecocktaildb.com/api/json/v1/%s/search.php?s=%s" % (api_key, drink))
     json_res = response.json()
     drinksArray = json_res["drinks"]
     if (drinksArray == None):                           # No options


### PR DESCRIPTION
Adds the API key from the environment variable to the url, if it is not available, then it simply uses the testing API key on the Cocktails DB. The api key is entered in the lambda configuration setting labeled "Environment variables" with the key `COCKTAIL_DB_API_KEY` as such:
![image](https://user-images.githubusercontent.com/6405150/36813432-8d689512-1ca2-11e8-8bbc-fc36b6296445.png)
This is already configured on AWS with the api key given to our team, so the lambda function should use that one.

Closes #4 
